### PR TITLE
Fix vim pack README.md incorrect directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ Then run
 :PluginInstall
 ```
 
-If you are using Vim 8+, you don't need any plugin manager. Simply clone this repository inside `~/.vim/pack/plugin/start/` directory and restart Vim.
+If you are using Vim 8+, you don't need any plugin manager. Simply clone this repository inside `~/.vim/pack/plugin/start/config/` directory and restart Vim.
 
 ```
-git clone git@github.com:christoomey/vim-tmux-navigator.git ~/.vim/pack/plugin/start/
+git clone git@github.com:christoomey/vim-tmux-navigator.git ~/.vim/pack/plugin/start/config/
 ```
 
 


### PR DESCRIPTION
On Ubuntu 20.04 with tmux 3.0a and vim 8.1.2269

After following instructions to clone this repo into `~/.vim/pack/plugin/start/`, navigation from vim -> tmux did not work. Vim plugin directory layout expects a `config` subdirectory after the `start` directory. The fixed lines point to the correct location to clone this repo so that vim will load the plugin.